### PR TITLE
feature/サイドバーメニュー拡充

### DIFF
--- a/src/mysfa/forms.py
+++ b/src/mysfa/forms.py
@@ -9,6 +9,16 @@ class GroupForm(forms.ModelForm):
     class Meta:
         model = Group
         fields = ["name"]
+        labels = {"name": "グループ名"}
+        widgets = {
+            "name": forms.TextInput(
+                attrs={
+                    "class": "create-group-input",
+                    "placeholder": "例）営業1課 共有グループ",
+                    "autocomplete": "organization",
+                }
+            )
+        }
 
 class ProductMasterForm(forms.ModelForm):
     class Meta:

--- a/src/mysfa/urls.py
+++ b/src/mysfa/urls.py
@@ -7,6 +7,7 @@ from .views import (
     DeleteGroupView,
     GroupAdminView,
     GroupPost,
+    MyGroupsApiView,
     GroupMembershipUpdateView,
     GroupTransferOwnerView,
     JoinGroupRequestView,
@@ -50,6 +51,7 @@ app_name = "mysfa"
 urlpatterns = [
     path("", RedirectView.as_view(url="timeline/", permanent=False), name="mysfa_root"),
     path("timeline/", Timeline.as_view(), name="timeline"),
+    path("api/my-groups/", MyGroupsApiView.as_view(), name="my_groups_api"),
     path("mypost/<str:custom_user_id>/", MyPost.as_view(), name="mypost"),
     path(
         "mypost/<str:custom_user_id>/update_username/",

--- a/src/mysfa/views.py
+++ b/src/mysfa/views.py
@@ -2,6 +2,7 @@ import csv
 import secrets
 import uuid
 from datetime import datetime, timedelta
+from urllib.parse import urlencode
 
 from django.contrib import messages
 from django.contrib.auth import login
@@ -16,6 +17,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_POST
 from django.utils.html import format_html
 from django.views import View
@@ -546,6 +548,13 @@ class IndustryMasterSearchApiView(LoginRequiredMixin, View):
             qs = qs.filter(name__icontains=q)
 
         results = [{"id": m.id, "name": m.name, "label": m.name} for m in qs[:limit]]
+        return JsonResponse({"results": results})
+
+
+class MyGroupsApiView(LoginRequiredMixin, View):
+    def get(self, request):
+        qs = Group.objects.filter(users=request.user, is_active=True).order_by("name", "custom_id")
+        results = [{"custom_id": g.custom_id, "name": g.name} for g in qs]
         return JsonResponse({"results": results})
 
 
@@ -1600,15 +1609,60 @@ class CreateGroupView(View):
 
 class SearchGroupView(LoginRequiredMixin, View):
     def get(self, request):
-        query = request.GET.get("q", "")
-        groups = (
-            Group.objects.filter(name__icontains=query, is_active=True)
-            .filter(Q(users__isnull=False) | Q(custom_id="72014332"))
-            .distinct()
+        query = (request.GET.get("q") or "").strip()
+        match_mode = request.GET.get("match") or "partial"
+        membership = request.GET.get("membership") or "all"
+        lock_filter = request.GET.get("lock") or "all"
+
+        groups = Group.objects.filter(is_active=True).filter(
+            Q(users__isnull=False) | Q(custom_id="72014332")
         )
+
+        if query:
+            if match_mode == "exact":
+                groups = groups.filter(Q(name__iexact=query) | Q(custom_id__iexact=query))
+            else:
+                match_mode = "partial"
+                groups = groups.filter(Q(name__icontains=query) | Q(custom_id__icontains=query))
+
+        if membership == "joined":
+            groups = groups.filter(users=request.user)
+        elif membership == "not_joined":
+            groups = groups.exclude(users=request.user)
+        else:
+            membership = "all"
+
+        if lock_filter == "locked":
+            groups = groups.filter(is_locked=True)
+        elif lock_filter == "open":
+            groups = groups.filter(is_locked=False)
+        else:
+            lock_filter = "all"
+
+        groups = groups.distinct().order_by("name", "custom_id")
+
+        group_ids = list(groups.values_list("id", flat=True))
+        requested_ids = set(
+            JoinRequest.objects.filter(user=request.user, group_id__in=group_ids).values_list(
+                "group_id", flat=True
+            )
+        )
+
         for group in groups:
-            group.is_member = group.users.filter(custom_user_id=request.user.custom_user_id).exists()
-        return render(request, "group/search_group.html", {"groups": groups, "query": query})
+            group.is_member = group.users.filter(pk=request.user.pk).exists()
+            group.user_has_requested = group.id in requested_ids
+
+        return render(
+            request,
+            "group/search_group.html",
+            {
+                "groups": groups,
+                "query": query,
+                "match_mode": match_mode,
+                "membership": membership,
+                "lock_filter": lock_filter,
+            },
+        )
 
     def post(self, request, custom_id):
         group = Group.objects.get(custom_id=custom_id, is_active=True)
@@ -1619,28 +1673,60 @@ class SearchGroupView(LoginRequiredMixin, View):
 
 class SearchProductsView(LoginRequiredMixin, View):
     def get(self, request):
-        query = request.GET.get("q", "")
-        selected_group_id = request.GET.get("custom_id")
-        user_groups = request.user.groups.all()
+        query = (request.GET.get("q") or "").strip()
+        match_mode = request.GET.get("match") or "partial"
+        start_date_raw = (request.GET.get("start_date") or "").strip()
+        end_date_raw = (request.GET.get("end_date") or "").strip()
+
+        selected_group_custom_id = (request.GET.get("group") or "").strip()
+        legacy_group_pk = (request.GET.get("custom_id") or "").strip()
+
+        user_groups = Group.objects.filter(users=request.user, is_active=True).order_by("name", "custom_id")
         page = request.GET.get("page", 1)
 
-        if query:
-            if selected_group_id:
-                posts = (
-                    Post.objects.filter(group__id=selected_group_id, group__in=user_groups)
-                    .select_related("user", "group", "product", "industry")
-                    .prefetch_related("liked_users", "comments__author")
-                    .filter(Q(product__product_code__icontains=query) | Q(product__name__icontains=query))
-                )
-            else:
-                posts = (
-                    Post.objects.filter(group__in=user_groups)
-                    .select_related("user", "group", "product", "industry")
-                    .prefetch_related("liked_users", "comments__author")
-                    .filter(Q(product__product_code__icontains=query) | Q(product__name__icontains=query))
-                )
-        else:
-            posts = []
+        date_error = None
+        start_date = None
+        end_date = None
+        if start_date_raw:
+            try:
+                start_date = datetime.strptime(start_date_raw, "%Y-%m-%d").date()
+            except ValueError:
+                date_error = "開始日の形式が正しくありません。"
+        if end_date_raw:
+            try:
+                end_date = datetime.strptime(end_date_raw, "%Y-%m-%d").date()
+            except ValueError:
+                date_error = "終了日の形式が正しくありません。"
+
+        if not selected_group_custom_id and legacy_group_pk:
+            g = user_groups.filter(pk=legacy_group_pk).first()
+            if g:
+                selected_group_custom_id = g.custom_id
+
+        do_search = bool(query or start_date or end_date)
+        posts = Post.objects.none()
+        if do_search:
+            posts = (
+                Post.objects.filter(group__in=user_groups)
+                .select_related("user", "group", "product", "industry")
+                .prefetch_related("liked_users", "comments__author")
+            )
+
+            if selected_group_custom_id:
+                posts = posts.filter(group__group__custom_id=selected_group_custom_id)
+
+            if start_date:
+                posts = posts.filter(created_at__date__gte=start_date)
+            if end_date:
+                posts = posts.filter(created_at__date__lte=end_date)
+
+            if query:
+                if match_mode == "exact":
+                    qf = Q(product__product_code__iexact=query) | Q(product__name__iexact=query)
+                else:
+                    match_mode = "partial"
+                    qf = Q(product__product_code__icontains=query) | Q(product__name__icontains=query)
+                posts = posts.filter(qf)
 
         paginator = Paginator(posts, 5)
         try:
@@ -1650,11 +1736,29 @@ class SearchProductsView(LoginRequiredMixin, View):
         except EmptyPage:
             object_list = paginator.page(paginator.num_pages)
 
+        params = {}
+        if query:
+            params["q"] = query
+        if selected_group_custom_id:
+            params["group"] = selected_group_custom_id
+        if match_mode and match_mode != "partial":
+            params["match"] = match_mode
+        if start_date_raw:
+            params["start_date"] = start_date_raw
+        if end_date_raw:
+            params["end_date"] = end_date_raw
+
         context = {
             "query": query,
             "object_list": object_list,
             "user_groups": user_groups,
-            "selected_group_id": selected_group_id,
+            "selected_group_custom_id": selected_group_custom_id,
+            "match_mode": match_mode,
+            "start_date": start_date_raw,
+            "end_date": end_date_raw,
+            "date_error": date_error,
+            "query_params": urlencode(params),
+            "did_search": do_search,
         }
         return render(request, "post/search_products.html", context)
 
@@ -1666,29 +1770,67 @@ class SearchProductsView(LoginRequiredMixin, View):
                 post.image.delete(save=False)
             post.delete()
             messages.success(request, "投稿を削除しました。")
+            next_url = (request.POST.get("next") or "").strip()
+            if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts={request.get_host()}):
+                return redirect(next_url)
             return redirect("mysfa:search_products")
 
 
 class SearchCustomersView(LoginRequiredMixin, View):
     def get(self, request):
-        query = request.GET.get("q", "")
-        selected_group_id = request.GET.get("custom_id")
-        user_groups = request.user.groups.all()
+        query = (request.GET.get("q") or "").strip()
+        match_mode = request.GET.get("match") or "partial"
+        start_date_raw = (request.GET.get("start_date") or "").strip()
+        end_date_raw = (request.GET.get("end_date") or "").strip()
+
+        selected_group_custom_id = (request.GET.get("group") or "").strip()
+        legacy_group_pk = (request.GET.get("custom_id") or "").strip()
+
+        user_groups = Group.objects.filter(users=request.user, is_active=True).order_by("name", "custom_id")
         page = request.GET.get("page", 1)
 
-        if query:
-            if selected_group_id:
-                customers = Post.objects.filter(
-                    industry__name__icontains=query,
-                    group__id=selected_group_id,
-                    group__in=user_groups,
-                ).select_related("user", "group", "product", "industry").prefetch_related("liked_users", "comments__author")
-            else:
-                customers = Post.objects.filter(
-                    industry__name__icontains=query, group__in=user_groups
-                ).select_related("user", "group", "product", "industry").prefetch_related("liked_users", "comments__author")
-        else:
-            customers = []
+        date_error = None
+        start_date = None
+        end_date = None
+        if start_date_raw:
+            try:
+                start_date = datetime.strptime(start_date_raw, "%Y-%m-%d").date()
+            except ValueError:
+                date_error = "開始日の形式が正しくありません。"
+        if end_date_raw:
+            try:
+                end_date = datetime.strptime(end_date_raw, "%Y-%m-%d").date()
+            except ValueError:
+                date_error = "終了日の形式が正しくありません。"
+
+        if not selected_group_custom_id and legacy_group_pk:
+            g = user_groups.filter(pk=legacy_group_pk).first()
+            if g:
+                selected_group_custom_id = g.custom_id
+
+        do_search = bool(query or start_date or end_date)
+        customers = Post.objects.none()
+        if do_search:
+            customers = (
+                Post.objects.filter(group__in=user_groups)
+                .select_related("user", "group", "product", "industry")
+                .prefetch_related("liked_users", "comments__author")
+            )
+
+            if selected_group_custom_id:
+                customers = customers.filter(group__group__custom_id=selected_group_custom_id)
+
+            if start_date:
+                customers = customers.filter(created_at__date__gte=start_date)
+            if end_date:
+                customers = customers.filter(created_at__date__lte=end_date)
+
+            if query:
+                if match_mode == "exact":
+                    customers = customers.filter(industry__name__iexact=query)
+                else:
+                    match_mode = "partial"
+                    customers = customers.filter(industry__name__icontains=query)
 
         paginator = Paginator(customers, 5)
         try:
@@ -1698,11 +1840,29 @@ class SearchCustomersView(LoginRequiredMixin, View):
         except EmptyPage:
             object_list = paginator.page(paginator.num_pages)
 
+        params = {}
+        if query:
+            params["q"] = query
+        if selected_group_custom_id:
+            params["group"] = selected_group_custom_id
+        if match_mode and match_mode != "partial":
+            params["match"] = match_mode
+        if start_date_raw:
+            params["start_date"] = start_date_raw
+        if end_date_raw:
+            params["end_date"] = end_date_raw
+
         context = {
             "query": query,
             "object_list": object_list,
             "user_groups": user_groups,
-            "selected_group_id": selected_group_id,
+            "selected_group_custom_id": selected_group_custom_id,
+            "match_mode": match_mode,
+            "start_date": start_date_raw,
+            "end_date": end_date_raw,
+            "date_error": date_error,
+            "query_params": urlencode(params),
+            "did_search": do_search,
         }
         return render(request, "post/search_customers.html", context)
 
@@ -1714,18 +1874,39 @@ class SearchCustomersView(LoginRequiredMixin, View):
                 post.image.delete(save=False)
             post.delete()
             messages.success(request, "投稿を削除しました。")
+            next_url = (request.POST.get("next") or "").strip()
+            if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts={request.get_host()}):
+                return redirect(next_url)
             return redirect("mysfa:search_customers")
 
 
 class SearchUsersView(LoginRequiredMixin, View):
     def get(self, request):
-        query = request.GET.get("q", "")
+        query = (request.GET.get("q") or "").strip()
+        match_mode = request.GET.get("match") or "partial"
+        selected_group_custom_id = (request.GET.get("group") or "").strip()
         page = request.GET.get("page", 1)
 
-        if query:
-            users = CustomUser.objects.filter(Q(username__icontains=query) | Q(custom_user_id__icontains=query))
-        else:
-            users = CustomUser.objects.none()
+        user_groups = Group.objects.filter(users=request.user, is_active=True).order_by("name", "custom_id")
+        if selected_group_custom_id and not user_groups.filter(custom_id=selected_group_custom_id).exists():
+            selected_group_custom_id = ""
+
+        do_search = bool(query or selected_group_custom_id)
+        users = CustomUser.objects.none()
+        if do_search:
+            users = CustomUser.objects.all()
+
+            if selected_group_custom_id:
+                users = users.filter(user_groups__custom_id=selected_group_custom_id, user_groups__is_active=True)
+
+            if query:
+                if match_mode == "exact":
+                    users = users.filter(Q(username__iexact=query) | Q(custom_user_id__iexact=query))
+                else:
+                    match_mode = "partial"
+                    users = users.filter(Q(username__icontains=query) | Q(custom_user_id__icontains=query))
+
+            users = users.distinct().order_by("username", "custom_user_id")
 
         paginator = Paginator(users, 10)
         try:
@@ -1735,9 +1916,22 @@ class SearchUsersView(LoginRequiredMixin, View):
         except EmptyPage:
             object_list = paginator.page(paginator.num_pages)
 
+        params = {}
+        if query:
+            params["q"] = query
+        if selected_group_custom_id:
+            params["group"] = selected_group_custom_id
+        if match_mode and match_mode != "partial":
+            params["match"] = match_mode
+
         context = {
             "query": query,
             "object_list": object_list,
+            "user_groups": user_groups,
+            "selected_group_custom_id": selected_group_custom_id,
+            "match_mode": match_mode,
+            "query_params": urlencode(params),
+            "did_search": do_search,
         }
         return render(request, "post/search_users.html", context)
 
@@ -1886,7 +2080,7 @@ class SalesReportView(View):
         posts = posts.filter(status__in=[Post.Status.ADOPTED])
         product_data = list(
             posts.filter(product__isnull=False)
-            .values("product__name")
+            .values("product__product_code", "product__name")
             .annotate(count=Count("id"))
             .order_by("-count")
         )
@@ -1897,14 +2091,24 @@ class SalesReportView(View):
             .order_by("-count")
         )
 
-        product_data = [{"product_name": x["product__name"], "count": x["count"]} for x in product_data]
+        product_data = [
+            {
+                "product_name": x["product__name"],
+                "product_code": x["product__product_code"],
+                "label": x["product__name"],
+                "count": x["count"],
+            }
+            for x in product_data
+        ]
         customer_data = [{"customer_category": x["industry__name"], "count": x["count"]} for x in customer_data]
 
         if len(product_data) > 5:
             top_products = product_data[:5]
             other_count = sum(item["count"] for item in product_data[5:])
             if other_count > 0:
-                top_products.append({"product_name": "その他", "count": other_count})
+                top_products.append(
+                    {"product_name": "その他", "product_code": "", "label": "その他", "count": other_count}
+                )
             product_data = top_products
 
         if len(customer_data) > 5:

--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -99,20 +99,21 @@
         display: flex;
         flex-direction: column;
         height: 100%;
+        overflow-y: auto;
+        overflow-x: hidden;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-gutter: stable;
     }
 
     .sidebar-contents {
         flex-grow: 1; 
-        overflow-y: auto; 
+        overflow: visible; 
         padding: 0; 
         margin: 0; 
     }
 
     .sidebar-contents a:not(#account a)::before {
-        display: block;
-        content: "\25C0";
-        position: absolute;
-        left: 20px;
+        content: none;
     }
 
 
@@ -129,6 +130,125 @@
 
     .sidebar-contents a:hover {
         background-color: #f0f0f0; 
+    }
+
+    .sidebar-dropdown > .dropdown-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+    }
+
+    .dropdown-arrow {
+        display: inline-block;
+        transition: transform 160ms ease;
+        font-size: 14px;
+        line-height: 1;
+    }
+
+    .dropdown-arrow.rotate {
+        transform: rotate(180deg);
+    }
+
+    .dropdown-menu {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        border-top: 1px solid rgba(0, 0, 0, 0.08);
+        border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+        background: #fafafa;
+
+        max-height: 0;
+        opacity: 0;
+        transform: translateY(-6px);
+        overflow: hidden;
+        pointer-events: none;
+        transition:
+            max-height 220ms ease,
+            opacity 180ms ease,
+            transform 180ms ease,
+            padding 180ms ease;
+        will-change: max-height, opacity, transform;
+    }
+
+    .dropdown-menu.show {
+        max-height: 360px;
+        opacity: 1;
+        transform: translateY(0);
+        pointer-events: auto;
+        padding: 4px 0;
+        overflow-y: auto;
+        overflow-x: hidden;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .dropdown-menu a {
+        height: 56px;
+        line-height: 56px;
+        font-size: 16px;
+    }
+
+    .dropdown-menu a::before {
+        content: none !important;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .dropdown-menu {
+            transition: none;
+            transform: none;
+        }
+    }
+
+    .group-master-results {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .group-master-result-btn {
+        width: 100%;
+        text-align: left;
+        padding: 10px 12px;
+        border-radius: 12px;
+        border: 1px solid #e5e7eb;
+        background: #fff;
+        color: #0f172a;
+        font-weight: 900;
+        cursor: pointer;
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 12px;
+    }
+
+    .group-master-result-btn:hover {
+        border-color: #39AEC8;
+        box-shadow: 0 10px 18px rgba(2, 6, 23, 0.06);
+    }
+
+    .group-master-result__name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        flex: 1 1 auto;
+    }
+
+    .group-master-result__id {
+        font-size: 12px;
+        font-weight: 900;
+        letter-spacing: 0.06em;
+        color: #334155;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        flex: 0 0 auto;
+    }
+
+    .group-master-empty {
+        margin: 0;
+        color: #666;
+        font-weight: 800;
     }
 
     #account {
@@ -815,6 +935,74 @@
         text-decoration: underline;
     }
 
+    .search-group-form.search-form-advanced {
+        display: block;
+    }
+
+    .search-group-input {
+        height: 42px;
+        margin-right: 0;
+    }
+
+    .search-group-button {
+        height: 42px;
+        font-weight: 900;
+        letter-spacing: 0.02em;
+        box-shadow: 0 6px 16px rgba(2, 6, 23, 0.08);
+        transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.2s ease;
+    }
+
+    .search-group-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 22px rgba(2, 6, 23, 0.12);
+    }
+
+    .search-form-advanced__grid.search-group-filters {
+        grid-template-columns: 1fr 1fr 1.2fr;
+    }
+
+    .group-meta {
+        margin-top: 4px;
+        color: #64748b;
+        font-weight: 800;
+        font-size: 12px;
+    }
+
+    .group-meta__id {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        letter-spacing: 0.04em;
+    }
+
+    .sales-report-empty {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+        padding: 16px 0 4px;
+        text-align: center;
+    }
+
+    .sales-report-section.is-empty .sales-report-empty {
+        flex: 1;
+        min-height: 260px;
+    }
+
+    .sales-report-empty__img {
+        width: min(220px, 60%);
+        height: auto;
+        opacity: 0.95;
+        filter: drop-shadow(0 10px 18px rgba(2, 6, 23, 0.08));
+        user-select: none;
+        pointer-events: none;
+    }
+
+    .sales-report-empty__text {
+        margin: 0;
+        color: #64748b;
+        font-weight: 900;
+    }
+
     .group-members {
         font-size: 14px;
         color: #666;
@@ -876,18 +1064,203 @@
 
     /*create-group*/
     .create-group-area {
-        width: 80%;
-        margin: 0 auto;
-        padding: 20px;
-        background-color: #f9f9f9;
-        border-radius: 10px;
-        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        width: min(920px, 92%);
+        margin: 20px auto 0;
+        padding: 0;
+        background: transparent;
+        border-radius: 0;
+        box-shadow: none;
     }
 
     .lock-info {
-        font-size: 10px;
-        font-weight: normal;
-        color: #707070;
+        font-size: 12px;
+        font-weight: 750;
+        color: #64748b;
+        line-height: 1.6;
+        margin: 6px 0 0;
+    }
+
+    .create-group-card {
+        background: #fff;
+        border: 1px solid #e5e7eb;
+        border-radius: 16px;
+        box-shadow: 0 18px 40px rgba(2, 6, 23, 0.08);
+        overflow: hidden;
+    }
+
+    .create-group-card__header {
+        padding: 18px 18px 14px;
+        background: #fff;
+        border-bottom: 1px solid #e5e7eb;
+        text-align: center;
+    }
+
+    .create-group-card__title {
+        margin: 0;
+        font-size: 22px;
+        font-weight: 900;
+        color: #0f172a;
+        letter-spacing: 0.02em;
+    }
+
+    .create-group-card__subtitle {
+        margin: 8px 0 0;
+        color: #64748b;
+        font-weight: 800;
+        font-size: 13px;
+    }
+
+    .create-group-form {
+        padding: 18px;
+        display: grid;
+        gap: 14px;
+    }
+
+    .create-group-form__field label {
+        display: block;
+        margin-bottom: 6px;
+        font-weight: 900;
+        color: #0f172a;
+    }
+
+    .create-group-input {
+        width: 100%;
+        height: 46px;
+        padding: 10px 12px;
+        border-radius: 12px;
+        border: 1px solid #d1d5db;
+        background: #fff;
+        font-size: 16px;
+        font-weight: 800;
+        color: #0f172a;
+        transition: box-shadow 0.2s ease, border-color 0.2s ease;
+    }
+
+    .create-group-input:focus {
+        outline: none;
+        border-color: #39AEC8;
+        box-shadow: 0 0 0 3px rgba(57, 174, 200, 0.18);
+    }
+
+    .create-group-form__error {
+        margin: 8px 0 0;
+        color: #b91c1c;
+        font-weight: 900;
+        font-size: 12px;
+    }
+
+    .create-group-form__panel {
+        border: 1px solid #e5e7eb;
+        background: #f8fafc;
+        border-radius: 14px;
+        padding: 14px;
+    }
+
+    .create-group-switch {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        cursor: pointer;
+        user-select: none;
+    }
+
+    .create-group-switch input {
+        position: absolute;
+        opacity: 0;
+        pointer-events: none;
+    }
+
+    .create-group-switch__ui {
+        width: 46px;
+        height: 28px;
+        border-radius: 999px;
+        background: #cbd5e1;
+        position: relative;
+        transition: background-color 180ms ease;
+        flex: 0 0 auto;
+        box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+    }
+
+    .create-group-switch__ui::after {
+        content: "";
+        width: 22px;
+        height: 22px;
+        border-radius: 999px;
+        background: #fff;
+        position: absolute;
+        top: 3px;
+        left: 3px;
+        transition: transform 180ms ease;
+        box-shadow: 0 8px 16px rgba(2, 6, 23, 0.18);
+    }
+
+    .create-group-switch:has(input:checked) .create-group-switch__ui {
+        background: #39AEC8;
+    }
+
+    .create-group-switch:has(input:checked) .create-group-switch__ui::after {
+        transform: translateX(18px);
+    }
+
+    .create-group-switch__label {
+        font-weight: 900;
+        color: #0f172a;
+    }
+
+    .create-group-form__actions {
+        display: flex;
+        gap: 10px;
+        justify-content: center;
+        flex-wrap: wrap;
+        margin-top: 6px;
+    }
+
+    .create-group-btn {
+        height: 44px;
+        padding: 0 16px;
+        border-radius: 12px;
+        border: 1px solid transparent;
+        font-size: 16px;
+        font-weight: 900;
+        cursor: pointer;
+        text-decoration: none;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+        min-width: 160px;
+    }
+
+    .create-group-btn--primary {
+        background: #39AEC8;
+        color: #fff;
+        box-shadow: 0 10px 22px rgba(2, 6, 23, 0.12);
+    }
+
+    .create-group-btn--primary:hover {
+        background: #2a8ca1;
+        transform: translateY(-1px);
+        box-shadow: 0 14px 28px rgba(2, 6, 23, 0.16);
+    }
+
+    .create-group-btn--ghost {
+        background: #fff;
+        color: #0f172a;
+        border-color: #d1d5db;
+    }
+
+    .create-group-btn--ghost:hover {
+        border-color: #39AEC8;
+        color: #39AEC8;
+        box-shadow: 0 0 0 3px rgba(57, 174, 200, 0.18);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .create-group-btn,
+        .create-group-switch__ui,
+        .create-group-switch__ui::after {
+            transition: none;
+        }
     }
 
     /*footer*/
@@ -2746,6 +3119,152 @@
         margin-bottom: 20px;
     }
 
+    .search-form-advanced {
+        display: block;
+    }
+
+    .search-form-advanced__row {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-bottom: 12px;
+    }
+
+    .search-products-input,
+    .search-customers-input {
+        height: 42px;
+    }
+
+    .search-products-button,
+    .search-customers-button {
+        height: 42px;
+        font-size: 16px;
+        font-weight: 900;
+        letter-spacing: 0.02em;
+        box-shadow: 0 6px 16px rgba(2, 6, 23, 0.08);
+        transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.2s ease;
+    }
+
+    .search-products-button:hover,
+    .search-customers-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 22px rgba(2, 6, 23, 0.12);
+    }
+
+    .search-form-advanced__clear {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        height: 42px;
+        padding: 0 12px;
+        border-radius: 8px;
+        border: 1px solid #d1d5db;
+        background: #fff;
+        color: #0f172a;
+        text-decoration: none;
+        font-weight: 900;
+        font-size: 16px;
+        transition: border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .search-form-advanced__clear:hover {
+        border-color: #39AEC8;
+        color: #39AEC8;
+        box-shadow: 0 0 0 3px rgba(57, 174, 200, 0.18);
+    }
+
+    .search-form-advanced__filters {
+        margin-top: 0;
+        border: 1px solid #e5e7eb;
+        background: #fff;
+    }
+
+    .search-form-advanced__grid {
+        display: grid;
+        grid-template-columns: 1.2fr 0.9fr 1.2fr;
+        gap: 14px;
+        align-items: end;
+    }
+
+    .search-form-advanced__field label {
+        display: block;
+        margin-bottom: 6px;
+    }
+
+    .search-form-advanced__label {
+        display: block;
+        font-weight: bold;
+        color: #333;
+        margin-bottom: 6px;
+    }
+
+    .search-form-advanced__dates {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+    }
+
+    .search-form-advanced__dates input[type="date"] {
+        padding: 10px;
+        border: 1px solid #ccc;
+        border-radius: 5px;
+        background: #fff;
+    }
+
+    .search-form-advanced__date-sep {
+        color: #64748b;
+        font-weight: 900;
+    }
+
+    .search-form-advanced__error {
+        width: 80%;
+        max-width: 920px;
+        margin: 10px auto 0;
+        color: #b91c1c;
+        font-weight: 900;
+        text-align: center;
+    }
+
+    .match-radio {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+    }
+
+    .match-radio__item {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 10px;
+        border-radius: 999px;
+        border: 1px solid #d1d5db;
+        background: #fff;
+        font-weight: 900;
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .match-radio__item input {
+        accent-color: #39AEC8;
+    }
+
+    .match-radio__item:has(input:checked) {
+        border-color: #39AEC8;
+        background: #e6f7fb;
+        box-shadow: 0 0 0 3px rgba(57, 174, 200, 0.15);
+    }
+
+    @media (max-width: 720px) {
+        .search-form-advanced__grid {
+            grid-template-columns: 1fr;
+        }
+    }
+
     .search-products-input {
         width: 70%;
         padding: 10px;
@@ -2864,6 +3383,10 @@
         margin-bottom: 20px;
     }
 
+    .search-customers-form.search-form-advanced {
+        display: block;
+    }
+
     .search-customers-input {
         width: 70%;
         padding: 10px;
@@ -2939,6 +3462,32 @@
 
     .search-users-button:hover {
         background-color: #2a8ca1;
+    }
+
+    .search-users-form.search-form-advanced {
+        display: block;
+    }
+
+    .search-users-input {
+        height: 42px;
+        margin-right: 0;
+    }
+
+    .search-users-button {
+        height: 42px;
+        font-weight: 900;
+        letter-spacing: 0.02em;
+        box-shadow: 0 6px 16px rgba(2, 6, 23, 0.08);
+        transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.2s ease;
+    }
+
+    .search-users-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 22px rgba(2, 6, 23, 0.12);
+    }
+
+    .search-form-advanced__grid.search-users-filters {
+        grid-template-columns: 1.2fr 1.4fr;
     }
 
 
@@ -4056,6 +4605,11 @@
         width: 80%;
     }
 
+    .sales-report-section.is-empty {
+        display: flex;
+        flex-direction: column;
+    }
+
     .sales-report-section h2 {
         color: #333;
         margin-bottom: 20px;
@@ -4123,6 +4677,10 @@
         min-height: 450px;
         max-width: 100%;
         overflow: hidden;
+    }
+
+    .sales-report-section.is-empty .charts-container {
+        display: none;
     }
 
     .chart-wrapper {

--- a/src/static/images/error.png
+++ b/src/static/images/error.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:918847234b91fb9307d42b234eedaa6bf28aca86a0a4ee27408994747f8e35e2
+size 93159

--- a/src/static/js/base-ui.js
+++ b/src/static/js/base-ui.js
@@ -39,11 +39,14 @@ document.addEventListener("DOMContentLoaded", function () {
 
   const dropdownToggles = document.querySelectorAll(".dropdown-toggle");
   dropdownToggles.forEach((toggle) => {
-    toggle.addEventListener("click", function () {
+    toggle.addEventListener("click", function (e) {
+      if (e && typeof e.preventDefault === "function") e.preventDefault();
       const dropdownMenu = this.nextElementSibling;
       const dropdownArrow = this.querySelector(".dropdown-arrow");
       if (dropdownMenu) dropdownMenu.classList.toggle("show");
       if (dropdownArrow) dropdownArrow.classList.toggle("rotate");
+      const expanded = dropdownMenu && dropdownMenu.classList.contains("show");
+      this.setAttribute("aria-expanded", expanded ? "true" : "false");
     });
   });
 

--- a/src/static/js/group-master-selector.js
+++ b/src/static/js/group-master-selector.js
@@ -1,0 +1,123 @@
+function escapeHtml(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const openLinks = Array.from(document.querySelectorAll(".js-open-group-master"));
+  const overlay = document.getElementById("group-master-modal-overlay");
+  const modal = document.getElementById("group-master-modal");
+  const closeBtn = document.getElementById("group-master-modal-close");
+  const results = document.getElementById("group-master-modal-results");
+  const empty = document.getElementById("group-master-modal-empty");
+
+  if (!openLinks.length || !overlay || !modal || !closeBtn || !results || !empty) return;
+
+  let mode = null; // "product" | "industry" | "group"
+  let cachedGroups = null; // [{custom_id,name}]
+
+  function openModal(nextMode) {
+    mode = nextMode;
+    overlay.classList.add("is-open");
+    modal.classList.add("is-open");
+    overlay.setAttribute("aria-hidden", "false");
+    modal.setAttribute("aria-hidden", "false");
+    renderGroups(cachedGroups);
+    if (!cachedGroups) loadGroups();
+  }
+
+  function closeModal() {
+    overlay.classList.remove("is-open");
+    modal.classList.remove("is-open");
+    overlay.setAttribute("aria-hidden", "true");
+    modal.setAttribute("aria-hidden", "true");
+    mode = null;
+  }
+
+  function buildTargetUrl(customId) {
+    if (mode === "group") {
+      return `/mysfa/group/${encodeURIComponent(customId)}/`;
+    }
+    return mode === "industry"
+      ? `/mysfa/group/${encodeURIComponent(customId)}/industry-master/`
+      : `/mysfa/group/${encodeURIComponent(customId)}/product-master/`;
+  }
+
+  function renderGroups(groups) {
+    results.innerHTML = "";
+    if (!Array.isArray(groups) || groups.length === 0) {
+      empty.style.display = "block";
+      return;
+    }
+    empty.style.display = "none";
+
+    for (const g of groups) {
+      const cid = g?.custom_id;
+      const name = g?.name || "";
+      if (!cid) continue;
+
+      const li = document.createElement("li");
+      li.className = "group-master-result";
+      li.innerHTML = `<button type="button" class="group-master-result-btn" data-custom-id="${escapeHtml(
+        cid
+      )}">
+        <span class="group-master-result__name">${escapeHtml(name || cid)}</span>
+        <span class="group-master-result__id">${escapeHtml(cid)}</span>
+      </button>`;
+      results.appendChild(li);
+    }
+  }
+
+  async function loadGroups() {
+    try {
+      const res = await fetch("/mysfa/api/my-groups/", {
+        headers: { Accept: "application/json" },
+        credentials: "same-origin",
+      });
+      if (!res.ok) {
+        renderGroups([]);
+        return;
+      }
+      const ct = res.headers.get("content-type") || "";
+      if (!ct.includes("application/json")) {
+        renderGroups([]);
+        return;
+      }
+      const data = await res.json();
+      const list = Array.isArray(data.results) ? data.results : [];
+      cachedGroups = list;
+      renderGroups(cachedGroups);
+    } catch (_) {
+      renderGroups([]);
+    }
+  }
+
+  openLinks.forEach((a) => {
+    a.addEventListener("click", (e) => {
+      e.preventDefault();
+      const kind = a.getAttribute("data-master-kind");
+      if (kind === "industry") return openModal("industry");
+      if (kind === "group") return openModal("group");
+      return openModal("product");
+    });
+  });
+
+  closeBtn.addEventListener("click", closeModal);
+  overlay.addEventListener("click", closeModal);
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeModal();
+  });
+
+  results.addEventListener("click", (e) => {
+    const btn = e.target?.closest?.(".group-master-result-btn");
+    if (!btn || !mode) return;
+    const customId = btn.getAttribute("data-custom-id");
+    if (!customId) return;
+    window.location.href = buildTargetUrl(customId);
+  });
+});
+

--- a/src/static/js/sales-report.js
+++ b/src/static/js/sales-report.js
@@ -1,26 +1,52 @@
 let productChart = null;
 let customerChart = null;
 
+function getSalesReportEmptyImageUrl() {
+  const el = document.querySelector(".sales-report-assets[data-sales-report-empty-image]");
+  const url = el?.getAttribute?.("data-sales-report-empty-image");
+  return url || "/static/images/error.png";
+}
+
 function setSalesReportEmptyMessage(show) {
   const container = document.querySelector(".sales-report-section");
   if (!container) return;
+
+  const chartsContainer = container.querySelector(".charts-container");
 
   const id = "sales-report-empty-message";
   let el = document.getElementById(id);
 
   if (!show) {
     if (el) el.remove();
+    container.classList.remove("is-empty");
+    if (chartsContainer) {
+      chartsContainer.style.display = "";
+    }
     return;
   }
 
+  container.classList.add("is-empty");
+  if (chartsContainer) {
+    chartsContainer.style.display = "none";
+    chartsContainer.style.minHeight = "";
+  }
+
   if (!el) {
-    el = document.createElement("p");
+    el = document.createElement("div");
     el.id = id;
-    el.textContent = "投稿がありません";
-    el.style.textAlign = "center";
-    el.style.color = "#666";
-    el.style.marginTop = "10px";
-    el.style.marginBottom = "0";
+    el.className = "sales-report-empty";
+
+    const img = document.createElement("img");
+    img.className = "sales-report-empty__img";
+    img.alt = "";
+    img.src = getSalesReportEmptyImageUrl();
+
+    const p = document.createElement("p");
+    p.className = "sales-report-empty__text";
+    p.textContent = "該当するデータが見つかりませんでした。";
+
+    el.appendChild(img);
+    el.appendChild(p);
     container.appendChild(el);
   }
 }
@@ -87,9 +113,12 @@ function loadSalesReport() {
   const endDate = document.getElementById("end-date")?.value;
   if (!startDate || !endDate) return;
 
-  const url = getSalesReportUrl(startDate, endDate);
+  const rawUrl = getSalesReportUrl(startDate, endDate);
+  const urlObj = new URL(rawUrl, window.location.origin);
+  urlObj.searchParams.set("_", String(Date.now()));
+  const url = urlObj.toString();
 
-  fetch(url)
+  fetch(url, { cache: "no-store" })
     .then((response) => {
       if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
       return response.json();
@@ -100,8 +129,19 @@ function loadSalesReport() {
       const productData = Array.isArray(data.product_data) ? data.product_data : [];
       const customerData = Array.isArray(data.customer_data) ? data.customer_data : [];
 
+      const normalizeProductName = (s) => {
+        const raw = String(s || "").trim();
+        if (!raw) return "";
+        // "CODE 商品名" みたいな形で来ても商品名寄せにする
+        const m = raw.match(/^([A-Za-z0-9_-]{1,20})\s+(.+)$/);
+        if (m && m[2]) return String(m[2]).trim();
+        return raw;
+      };
+
       const normalized = {
-        labels: productData.map((x) => x.product_name),
+        labels: productData.map((x) =>
+          normalizeProductName(x?.label || x?.product_name || x?.product_code || "")
+        ),
         values: productData.map((x) => x.count),
         customer_labels: customerData.map((x) => x.customer_category),
         customer_values: customerData.map((x) => x.count),
@@ -133,11 +173,12 @@ function updateCharts(data) {
   if (productChart) productChart.destroy();
   if (customerChart) customerChart.destroy();
 
-  const colors = [
-    "#4e79a7", "#f28e2b", "#e15759", "#76b7b2", "#59a14f",
-    "#edc949", "#af7aa1", "#ff9da7", "#9c755f", "#bab0ab",
-  ];
-  const makeColors = (n) => Array.from({ length: n }, (_, i) => colors[i % colors.length]);
+  const colors = ["#2FBFD6", "#18ABCC", "#1399CF", "#1081C7", "#084F8C"];
+  const makeColors = (n) => {
+    const base = colors.slice(0, Math.max(0, n));
+    if (base.length >= n) return base;
+    return base.concat(Array.from({ length: n - base.length }, () => colors[colors.length - 1]));
+  };
 
   // 商品別
   productChart = new Chart(productCtx, {
@@ -182,7 +223,9 @@ function updateCharts(data) {
   });
 
   const chartsContainer = document.querySelector(".charts-container");
-  if (chartsContainer) chartsContainer.style.minHeight = "400px";
+  if (chartsContainer) chartsContainer.style.display = "";
+  const section = document.querySelector(".sales-report-section");
+  if (section) section.classList.remove("is-empty");
 }
 
 document.addEventListener("DOMContentLoaded", function () {

--- a/src/template/base.html
+++ b/src/template/base.html
@@ -151,10 +151,82 @@
                                 </a></li>
                         {% endif %}
                         <p id="search-for-category">カテゴリ別で探す</p>
-                        <li id="search-for-products"><a href="{% url 'mysfa:search_products' %}">商品</a></li>
-                        <li id="search-for-customer-category"><a href="{% url 'mysfa:search_customers' %}">業態</a></li>
-                        <li id="team"><a href="{% url 'mysfa:search_group' %}">グループ</a></li>
-                        <li id="search-for-users"><a href="{% url 'mysfa:search_users' %}">ユーザー</a></li>
+                        <li id="search-for-products" class="sidebar-dropdown">
+                            <a href="#" class="dropdown-toggle" role="button" aria-haspopup="true" aria-expanded="false">
+                                商品
+                                <span class="dropdown-arrow" aria-hidden="true">▾</span>
+                            </a>
+                            <ul class="dropdown-menu" aria-label="商品メニュー">
+                                {% if request.user.is_authenticated %}
+                                    <li>
+                                        <a href="#"
+                                           class="js-open-group-master"
+                                           data-master-kind="product"
+                                        >商品マスタ</a>
+                                    </li>
+                                {% else %}
+                                    <li><a href="{% url 'login' %}">商品マスタ（ログインが必要）</a></li>
+                                {% endif %}
+                                <li><a href="{% url 'mysfa:search_products' %}">投稿から商品を探す</a></li>
+                            </ul>
+                        </li>
+                        <li id="search-for-customer-category" class="sidebar-dropdown">
+                            <a href="#" class="dropdown-toggle" role="button" aria-haspopup="true" aria-expanded="false">
+                                業態
+                                <span class="dropdown-arrow" aria-hidden="true">▾</span>
+                            </a>
+                            <ul class="dropdown-menu" aria-label="業態メニュー">
+                                {% if request.user.is_authenticated %}
+                                    <li>
+                                        <a href="#"
+                                           class="js-open-group-master"
+                                           data-master-kind="industry"
+                                        >業態マスタ</a>
+                                    </li>
+                                {% else %}
+                                    <li><a href="{% url 'login' %}">業態マスタ（ログインが必要）</a></li>
+                                {% endif %}
+                                <li><a href="{% url 'mysfa:search_customers' %}">投稿から業態を探す</a></li>
+                            </ul>
+                        </li>
+                        <li id="team" class="sidebar-dropdown">
+                            <a href="#" class="dropdown-toggle" role="button" aria-haspopup="true" aria-expanded="false">
+                                グループ
+                                <span class="dropdown-arrow" aria-hidden="true">▾</span>
+                            </a>
+                            <ul class="dropdown-menu" aria-label="グループメニュー">
+                                {% if request.user.is_authenticated %}
+                                    <li>
+                                        <a href="#"
+                                           class="js-open-group-master"
+                                           data-master-kind="group"
+                                        >グループページ</a>
+                                    </li>
+                                {% else %}
+                                    <li><a href="{% url 'login' %}">グループページ（ログインが必要）</a></li>
+                                {% endif %}
+                                <li><a href="{% url 'mysfa:search_group' %}">グループ検索</a></li>
+                                {% if request.user.is_authenticated %}
+                                    <li><a href="{% url 'mysfa:create_group' %}">グループ作成</a></li>
+                                {% else %}
+                                    <li><a href="{% url 'login' %}">グループ作成（ログインが必要）</a></li>
+                                {% endif %}
+                            </ul>
+                        </li>
+                        <li id="search-for-users" class="sidebar-dropdown">
+                            <a href="#" class="dropdown-toggle" role="button" aria-haspopup="true" aria-expanded="false">
+                                ユーザー
+                                <span class="dropdown-arrow" aria-hidden="true">▾</span>
+                            </a>
+                            <ul class="dropdown-menu" aria-label="ユーザーメニュー">
+                                {% if request.user.is_authenticated %}
+                                    <li><a href="{% url 'mysfa:mypost' request.user.custom_user_id %}">マイページ</a></li>
+                                {% else %}
+                                    <li><a href="{% url 'login' %}">マイページ（ログインが必要）</a></li>
+                                {% endif %}
+                                <li><a href="{% url 'mysfa:search_users' %}">ユーザー検索</a></li>
+                            </ul>
+                        </li>
                         <p id="other-contents">その他</p>
                         <li id="privacy-policy-in-sidebar"><a href="{% url 'privacy-policy' %}">プライバシーポリシー</a></li>
                         <li id="terms-of-service-in-sidebar"><a href="{% url 'terms-of-service' %}">利用規約</a></li>
@@ -200,7 +272,24 @@
         </div>
     </footer>
 
+    <div id="group-master-modal-overlay" class="modal-overlay" aria-hidden="true"></div>
+    <div id="group-master-modal" class="modal" aria-hidden="true">
+        <div class="modal__content">
+            <div class="modal__header">
+                <h3 class="modal__title">グループを選択してください。</h3>
+                <button type="button" id="group-master-modal-close" class="modal__close" aria-label="閉じる">×</button>
+            </div>
+            <div class="modal__body">
+                <ul id="group-master-modal-results" class="group-master-results"></ul>
+                <p id="group-master-modal-empty" class="group-master-empty" style="display:none;">
+                    参加中のグループがありません。
+                </p>
+            </div>
+        </div>
+    </div>
+
     <script src="{% static 'js/base-ui.js' %}"></script>
+    <script src="{% static 'js/group-master-selector.js' %}"></script>
     <script src="{% static 'js/post-comments-toggle.js' %}"></script>
     <script>
         // data-confirm を付けたリンク/ボタンに「よろしいですか？」を挟む

--- a/src/template/group/create_group.html
+++ b/src/template/group/create_group.html
@@ -4,19 +4,42 @@
 {% block title %}グループ作成 | MySFA{% endblock %}
 {% block content %}
 <div class="create-group-area">
-    <h1 style="text-align: center; color: #333; font-size: 24px; margin-bottom: 20px;">グループを作成</h1>
-    <form method="post" action="{% url 'mysfa:create_group' %}" style="display: flex; flex-direction: column; gap: 15px;">
+    <div class="create-group-card">
+        <div class="create-group-card__header">
+            <h1 class="create-group-card__title">グループを作成</h1>
+        </div>
+
+        <form method="post" action="{% url 'mysfa:create_group' %}" class="create-group-form">
         {% csrf_token %}
-        <div style="padding: 10px; border: 1px solid #ccc; border-radius: 4px; cursor: text;" onclick="this.querySelector('input').focus();">
-            {{ form.as_p }}
-        </div>
-        <div style="padding: 10px; border: 1px solid #ccc; border-radius: 4px;">
-            <label for="id_is_locked">ロック機能を有効にする</label>
-            <input type="checkbox" id="id_is_locked" name="is_locked">
-            <p class="lock-info">ロック機能を有効にすると、メンバー以外のユーザーはグループの投稿やグループメンバーの閲覧ができなくなります。</p>
-            <p class="lock-info">新しくユーザーが参加する際は、メンバーの承認が必要になります。</p>
-        </div>
-        <button type="submit" style="display: block; padding: 10px 20px; min-width: 200px; max-width: 300px; margin: 0 auto; background-color: #39AEC8; color: white; border: none; border-radius: 4px; white-space: nowrap; cursor: pointer; text-align: center; font-size: 16px;">作成する</button>
-    </form>
+            {% if form.non_field_errors %}
+                <div class="create-group-form__errors" role="alert">
+                    {{ form.non_field_errors }}
+                </div>
+            {% endif %}
+
+            <div class="create-group-form__field">
+                <label for="{{ form.name.id_for_label }}">グループ名</label>
+                {{ form.name }}
+                {% if form.name.errors %}
+                    <p class="create-group-form__error">{{ form.name.errors|striptags }}</p>
+                {% endif %}
+            </div>
+
+            <div class="create-group-form__panel">
+                <label class="create-group-switch" for="id_is_locked">
+                    <input type="checkbox" id="id_is_locked" name="is_locked" {% if request.POST.is_locked %}checked{% endif %}>
+                    <span class="create-group-switch__ui" aria-hidden="true"></span>
+                    <span class="create-group-switch__label">ロック機能を有効にする</span>
+                </label>
+                <p class="lock-info">ロック機能を有効にすると、メンバー以外のユーザーはグループの投稿やグループメンバーの閲覧ができなくなります。</p>
+                <p class="lock-info">新しくユーザーが参加する際は、オーナーの承認が必要になります。</p>
+            </div>
+
+            <div class="create-group-form__actions">
+                <button type="submit" class="create-group-btn create-group-btn--primary">作成する</button>
+                <a href="{% url 'mysfa:search_group' %}" class="create-group-btn create-group-btn--ghost">キャンセル</a>
+            </div>
+        </form>
+    </div>
 </div>
 {% endblock %}

--- a/src/template/group/grouppost.html
+++ b/src/template/group/grouppost.html
@@ -115,6 +115,7 @@
 
 <div class="sales-report-section">
     <h2>グループ営業成果レポート</h2>
+    <div class="sales-report-assets" data-sales-report-empty-image="{% static 'images/error.png' %}" hidden></div>
     <div class="date-range-selector">
         <label for="start-date">開始日:</label>
         <input type="date" id="start-date" name="start-date">
@@ -341,5 +342,5 @@
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="{% static 'js/like.js' %}"></script>
-<script src="{% static 'js/sales-report.js' %}"></script>
+<script src="{% static 'js/sales-report.js' %}?v=20260205_3"></script>
 {% endblock %}

--- a/src/template/group/search_group.html
+++ b/src/template/group/search_group.html
@@ -5,9 +5,48 @@
 {% block content %}
     <div class="search-group-container">
         <h1>グループを検索</h1>
-        <form method="get" action="{% url 'mysfa:search_group' %}" class="search-group-form">
-            <input type="text" name="q" value="{{ query }}" placeholder="グループ名で検索" class="search-group-input">
-            <button type="submit" class="search-group-button">検索</button>
+        <form method="get" action="{% url 'mysfa:search_group' %}" class="search-group-form search-form-advanced">
+            <div class="search-form-advanced__row">
+                <input type="text" name="q" value="{{ query }}" placeholder="グループ名 / グループIDで検索" class="search-group-input">
+                <button type="submit" class="search-group-button">検索</button>
+                <a class="search-form-advanced__clear" href="{% url 'mysfa:search_group' %}">クリア</a>
+            </div>
+
+            <div class="filter-form search-form-advanced__filters" id="filter-form-group">
+                <div class="search-form-advanced__grid search-group-filters">
+                    <div class="search-form-advanced__field">
+                        <label for="membership">参加状況:</label>
+                        <select name="membership" id="membership">
+                            <option value="all" {% if membership == "all" %}selected{% endif %}>すべて</option>
+                            <option value="joined" {% if membership == "joined" %}selected{% endif %}>参加済み</option>
+                            <option value="not_joined" {% if membership == "not_joined" %}selected{% endif %}>未参加</option>
+                        </select>
+                    </div>
+
+                    <div class="search-form-advanced__field">
+                        <label for="lock">公開設定:</label>
+                        <select name="lock" id="lock">
+                            <option value="all" {% if lock_filter == "all" %}selected{% endif %}>すべて</option>
+                            <option value="open" {% if lock_filter == "open" %}selected{% endif %}>公開</option>
+                            <option value="locked" {% if lock_filter == "locked" %}selected{% endif %}>ロック</option>
+                        </select>
+                    </div>
+
+                    <div class="search-form-advanced__field">
+                        <span class="search-form-advanced__label">一致:</span>
+                        <div class="match-radio" role="radiogroup" aria-label="一致方法">
+                            <label class="match-radio__item">
+                                <input type="radio" name="match" value="partial" {% if match_mode == "partial" %}checked{% endif %}>
+                                <span>部分一致</span>
+                            </label>
+                            <label class="match-radio__item">
+                                <input type="radio" name="match" value="exact" {% if match_mode == "exact" %}checked{% endif %}>
+                                <span>完全一致</span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </form>
 
         {% if query %}
@@ -29,6 +68,9 @@
                             {% if group.is_locked %}
                                 <img src="{% static 'images/team/locked.png' %}" alt="ロックされたグループ" class="locked-group-icon">
                             {% endif %}
+                            <div class="group-meta">
+                                <span class="group-meta__id">ID: {{ group.custom_id }}</span>
+                            </div>
                         </div>
                         {% if group.is_member %}
                             <span class="joined-label">参加済み</span>

--- a/src/template/post/mypost.html
+++ b/src/template/post/mypost.html
@@ -68,6 +68,7 @@
 
 <div class="sales-report-section">
     <h2>営業成果レポート</h2>
+    <div class="sales-report-assets" data-sales-report-empty-image="{% static 'images/error.png' %}" hidden></div>
     <div class="date-range-selector">
         <label for="start-date">開始日:</label>
         <input type="date" id="start-date" name="start-date">
@@ -261,5 +262,5 @@
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="{% static 'js/like.js' %}"></script>
-<script src="{% static 'js/sales-report.js' %}"></script>
+<script src="{% static 'js/sales-report.js' %}?v=20260205_3"></script>
 {% endblock %}

--- a/src/template/post/search_customers.html
+++ b/src/template/post/search_customers.html
@@ -5,24 +5,56 @@
 {% block content %}
 <div class="search-customers-container">
     <h1>業態を検索</h1>
-    <form method="get" action="{% url 'mysfa:search_customers' %}" class="search-customers-form">
-        <input type="text" name="q" id="search-input" value="{{ query }}" placeholder="業態名で検索" class="search-customers-input">
-        <button type="submit" class="search-customers-button">検索</button>
+    <form method="get" action="{% url 'mysfa:search_customers' %}" class="search-customers-form search-form-advanced">
+        <div class="search-form-advanced__row">
+            <input type="text" name="q" id="search-input" value="{{ query }}" placeholder="業態名で検索" class="search-customers-input">
+            <button type="submit" class="search-customers-button">検索</button>
+            <a class="search-form-advanced__clear" href="{% url 'mysfa:search_customers' %}">クリア</a>
+        </div>
+
+        <div class="filter-form search-form-advanced__filters" id="filter-form-customers">
+            <div class="search-form-advanced__grid">
+                <div class="search-form-advanced__field">
+                    <label for="group">対象グループ:</label>
+                    <select name="group" id="group">
+                        <option value="">全て（所属グループ）</option>
+                        {% for group in user_groups %}
+                            <option value="{{ group.custom_id }}" {% if group.custom_id == selected_group_custom_id %}selected{% endif %}>{{ group.name }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <div class="search-form-advanced__field">
+                    <span class="search-form-advanced__label">一致:</span>
+                    <div class="match-radio" role="radiogroup" aria-label="一致方法">
+                        <label class="match-radio__item">
+                            <input type="radio" name="match" value="partial" {% if match_mode == "partial" %}checked{% endif %}>
+                            <span>部分一致</span>
+                        </label>
+                        <label class="match-radio__item">
+                            <input type="radio" name="match" value="exact" {% if match_mode == "exact" %}checked{% endif %}>
+                            <span>完全一致</span>
+                        </label>
+                    </div>
+                </div>
+
+                <div class="search-form-advanced__field">
+                    <label for="start_date">期間:</label>
+                    <div class="search-form-advanced__dates">
+                        <input type="date" name="start_date" id="start_date" value="{{ start_date }}">
+                        <span class="search-form-advanced__date-sep">〜</span>
+                        <input type="date" name="end_date" id="end_date" value="{{ end_date }}">
+                    </div>
+                </div>
+            </div>
+        </div>
     </form>
 
-    {% if query %}
-        <div class="filter-form" id="filter-form-customers">
-            <form method="get" action="{% url 'mysfa:search_customers' %}">
-                <input type="hidden" name="q" value="{{ query }}">
-                <label for="group">グループで絞り込む:</label>
-                <select name="custom_id" id="group" onchange="this.form.submit()">
-                    <option value="">全てのグループ</option>
-                    {% for group in user_groups %}
-                        <option value="{{ group.id }}" {% if group.id|stringformat:"s" == selected_group_id %}selected{% endif %}>{{ group.name }}</option>
-                    {% endfor %}
-                </select>
-            </form>
-        </div>
+    {% if date_error %}
+        <p class="search-form-advanced__error">{{ date_error }}</p>
+    {% endif %}
+
+    {% if did_search %}
         <div class="timeline-container" style="margin-top: 20px;">
             {% if object_list %}
                 {% for post in object_list %}
@@ -69,6 +101,7 @@
                                         <form method="post" action="{% url 'mysfa:search_customers' %}" onsubmit="return confirm('本当に削除しますか？');">
                                             {% csrf_token %}
                                             <input type="hidden" name="delete_post_id" value="{{ post.id }}">
+                                            <input type="hidden" name="next" value="{{ request.get_full_path }}">
                                             <button type="submit" class="delete-button">
                                                 <img src="{% static 'images/trash-solid.svg' %}" alt="削除" class="delete-icon">
                                             </button>
@@ -143,25 +176,25 @@
             <div class="pagination">
                 <span class="step-links">
                     {% if object_list.has_previous %}
-                        <a href="{% url 'mysfa:search_customers' %}?q={{ query }}&page=1{% if selected_group_id %}&custom_id={{ selected_group_id }}{% endif %}">&laquo; 最初</a>
-                        <a href="{% url 'mysfa:search_customers' %}?q={{ query }}&page={{ object_list.previous_page_number }}{% if selected_group_id %}&custom_id={{ selected_group_id }}{% endif %}">前</a>
+                        <a href="{% url 'mysfa:search_customers' %}?{% if query_params %}{{ query_params }}&{% endif %}page=1">&laquo; 最初</a>
+                        <a href="{% url 'mysfa:search_customers' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ object_list.previous_page_number }}">前</a>
                     {% endif %}
 
                     {% for page_num in object_list.paginator.page_range %}
                         {% if page_num == object_list.number %}
                             <span class="page-number current">{{ page_num }}</span>
                         {% elif page_num > object_list.number|add:'-3' and page_num < object_list.number|add:'3' %}
-                            <a href="{% url 'mysfa:search_customers' %}?q={{ query }}&page={{ page_num }}{% if selected_group_id %}&custom_id={{ selected_group_id }}{% endif %}" class="page-number">{{ page_num }}</a>
+                            <a href="{% url 'mysfa:search_customers' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ page_num }}" class="page-number">{{ page_num }}</a>
                         {% elif page_num == 1 or page_num == object_list.paginator.num_pages %}
-                            <a href="{% url 'mysfa:search_customers' %}?q={{ query }}&page={{ page_num }}{% if selected_group_id %}&custom_id={{ selected_group_id }}{% endif %}" class="page-number">{{ page_num }}</a>
+                            <a href="{% url 'mysfa:search_customers' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ page_num }}" class="page-number">{{ page_num }}</a>
                         {% elif page_num == object_list.number|add:'-3' or page_num == object_list.number|add:'3' %}
                             <span class="page-number">...</span>
                         {% endif %}
                     {% endfor %}
 
                     {% if object_list.has_next %}
-                        <a href="{% url 'mysfa:search_customers' %}?q={{ query }}&page={{ object_list.next_page_number }}{% if selected_group_id %}&custom_id={{ selected_group_id }}{% endif %}">次</a>
-                        <a href="{% url 'mysfa:search_customers' %}?q={{ query }}&page={{ object_list.paginator.num_pages }}{% if selected_group_id %}&custom_id={{ selected_group_id }}{% endif %}">最後 &raquo;</a>
+                        <a href="{% url 'mysfa:search_customers' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ object_list.next_page_number }}">次</a>
+                        <a href="{% url 'mysfa:search_customers' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ object_list.paginator.num_pages }}">最後 &raquo;</a>
                     {% endif %}
                 </span>
             </div>

--- a/src/template/post/search_products.html
+++ b/src/template/post/search_products.html
@@ -5,24 +5,56 @@
 {% block content %}
 <div class="search-products-container">
     <h1>商品を検索</h1>
-    <form method="get" action="{% url 'mysfa:search_products' %}" class="search-products-form">
-        <input type="text" name="q" id="search-input" value="{{ query }}" placeholder="商品コード / 商品名で検索" class="search-products-input">
-        <button type="submit" class="search-products-button">検索</button>
+    <form method="get" action="{% url 'mysfa:search_products' %}" class="search-products-form search-form-advanced">
+        <div class="search-form-advanced__row">
+            <input type="text" name="q" id="search-input" value="{{ query }}" placeholder="商品コード / 商品名で検索" class="search-products-input">
+            <button type="submit" class="search-products-button">検索</button>
+            <a class="search-form-advanced__clear" href="{% url 'mysfa:search_products' %}">クリア</a>
+        </div>
+
+        <div class="filter-form search-form-advanced__filters" id="filter-form-products">
+            <div class="search-form-advanced__grid">
+                <div class="search-form-advanced__field">
+                    <label for="group">対象グループ:</label>
+                    <select name="group" id="group">
+                        <option value="">全て（所属グループ）</option>
+                        {% for group in user_groups %}
+                            <option value="{{ group.custom_id }}" {% if group.custom_id == selected_group_custom_id %}selected{% endif %}>{{ group.name }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <div class="search-form-advanced__field">
+                    <span class="search-form-advanced__label">一致:</span>
+                    <div class="match-radio" role="radiogroup" aria-label="一致方法">
+                        <label class="match-radio__item">
+                            <input type="radio" name="match" value="partial" {% if match_mode == "partial" %}checked{% endif %}>
+                            <span>部分一致</span>
+                        </label>
+                        <label class="match-radio__item">
+                            <input type="radio" name="match" value="exact" {% if match_mode == "exact" %}checked{% endif %}>
+                            <span>完全一致</span>
+                        </label>
+                    </div>
+                </div>
+
+                <div class="search-form-advanced__field">
+                    <label for="start_date">期間:</label>
+                    <div class="search-form-advanced__dates">
+                        <input type="date" name="start_date" id="start_date" value="{{ start_date }}">
+                        <span class="search-form-advanced__date-sep">〜</span>
+                        <input type="date" name="end_date" id="end_date" value="{{ end_date }}">
+                    </div>
+                </div>
+            </div>
+        </div>
     </form>
 
-    {% if query %}
-        <div class="filter-form" id="filter-form-products">
-            <form method="get" action="{% url 'mysfa:search_products' %}">
-                <input type="hidden" name="q" value="{{ query }}">
-                <label for="group">グループで絞り込む:</label>
-                <select name="custom_id" id="group" onchange="this.form.submit()">
-                    <option value="">全てのグループ</option>
-                    {% for group in user_groups %}
-                        <option value="{{ group.id }}" {% if group.id|stringformat:"s" == selected_group_id %}selected{% endif %}>{{ group.name }}</option>
-                    {% endfor %}
-                </select>
-            </form>
-        </div>
+    {% if date_error %}
+        <p class="search-form-advanced__error">{{ date_error }}</p>
+    {% endif %}
+
+    {% if did_search %}
         <div class="timeline-container" style="margin-top: 20px;">
             {% if object_list %}
                 {% for post in object_list %}
@@ -69,6 +101,7 @@
                                         <form method="post" action="{% url 'mysfa:search_products' %}" onsubmit="return confirm('本当に削除しますか？');">
                                             {% csrf_token %}
                                             <input type="hidden" name="delete_post_id" value="{{ post.id }}">
+                                            <input type="hidden" name="next" value="{{ request.get_full_path }}">
                                             <button type="submit" class="delete-button">
                                                 <img src="{% static 'images/trash-solid.svg' %}" alt="削除" class="delete-icon">
                                             </button>
@@ -143,25 +176,25 @@
             <div class="pagination">
                 <span class="step-links">
                     {% if object_list.has_previous %}
-                        <a href="{% url 'mysfa:search_products' %}?q={{ query }}&page=1{% if selected_group_id %}&custom_id={{ selected_group_id }}{% endif %}">&laquo; 最初</a>
-                        <a href="{% url 'mysfa:search_products' %}?q={{ query }}&page={{ object_list.previous_page_number }}{% if selected_group_id %}&custom_id={{ selected_group_id }}{% endif %}">前</a>
+                        <a href="{% url 'mysfa:search_products' %}?{% if query_params %}{{ query_params }}&{% endif %}page=1">&laquo; 最初</a>
+                        <a href="{% url 'mysfa:search_products' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ object_list.previous_page_number }}">前</a>
                     {% endif %}
 
                     {% for page_num in object_list.paginator.page_range %}
                         {% if page_num == object_list.number %}
                             <span class="page-number current">{{ page_num }}</span>
                         {% elif page_num > object_list.number|add:'-3' and page_num < object_list.number|add:'3' %}
-                            <a href="{% url 'mysfa:search_products' %}?q={{ query }}&page={{ page_num }}{% if selected_group_id %}&custom_id={{ selected_group_id }}{% endif %}" class="page-number">{{ page_num }}</a>
+                            <a href="{% url 'mysfa:search_products' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ page_num }}" class="page-number">{{ page_num }}</a>
                         {% elif page_num == 1 or page_num == object_list.paginator.num_pages %}
-                            <a href="{% url 'mysfa:search_products' %}?q={{ query }}&page={{ page_num }}{% if selected_group_id %}&custom_id={{ selected_group_id }}{% endif %}" class="page-number">{{ page_num }}</a>
+                            <a href="{% url 'mysfa:search_products' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ page_num }}" class="page-number">{{ page_num }}</a>
                         {% elif page_num == object_list.number|add:'-3' or page_num == object_list.number|add:'3' %}
                             <span class="page-number">...</span>
                         {% endif %}
                     {% endfor %}
 
                     {% if object_list.has_next %}
-                        <a href="{% url 'mysfa:search_products' %}?q={{ query }}&page={{ object_list.next_page_number }}{% if selected_group_id %}&custom_id={{ selected_group_id }}{% endif %}">次</a>
-                        <a href="{% url 'mysfa:search_products' %}?q={{ query }}&page={{ object_list.paginator.num_pages }}{% if selected_group_id %}&custom_id={{ selected_group_id }}{% endif %}">最後 &raquo;</a>
+                        <a href="{% url 'mysfa:search_products' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ object_list.next_page_number }}">次</a>
+                        <a href="{% url 'mysfa:search_products' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ object_list.paginator.num_pages }}">最後 &raquo;</a>
                     {% endif %}
                 </span>
             </div>

--- a/src/template/post/search_users.html
+++ b/src/template/post/search_users.html
@@ -5,12 +5,43 @@
 {% block content %}
 <div class="search-users-container">
     <h1>ユーザーを検索</h1>
-    <form method="get" action="{% url 'mysfa:search_users' %}" class="search-users-form">
-        <input type="text" name="q" value="{{ query }}" placeholder="ユーザー名またはユーザーIDで検索" class="search-users-input">
-        <button type="submit" class="search-users-button">検索</button>
+    <form method="get" action="{% url 'mysfa:search_users' %}" class="search-users-form search-form-advanced">
+        <div class="search-form-advanced__row">
+            <input type="text" name="q" value="{{ query }}" placeholder="ユーザー名 / ユーザーIDで検索" class="search-users-input">
+            <button type="submit" class="search-users-button">検索</button>
+            <a class="search-form-advanced__clear" href="{% url 'mysfa:search_users' %}">クリア</a>
+        </div>
+
+        <div class="filter-form search-form-advanced__filters" id="filter-form-users">
+            <div class="search-form-advanced__grid search-users-filters">
+                <div class="search-form-advanced__field">
+                    <label for="group">対象所属グループ:</label>
+                    <select name="group" id="group">
+                        <option value="">全て</option>
+                        {% for group in user_groups %}
+                            <option value="{{ group.custom_id }}" {% if group.custom_id == selected_group_custom_id %}selected{% endif %}>{{ group.name }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <div class="search-form-advanced__field">
+                    <span class="search-form-advanced__label">一致:</span>
+                    <div class="match-radio" role="radiogroup" aria-label="一致方法">
+                        <label class="match-radio__item">
+                            <input type="radio" name="match" value="partial" {% if match_mode == "partial" %}checked{% endif %}>
+                            <span>部分一致</span>
+                        </label>
+                        <label class="match-radio__item">
+                            <input type="radio" name="match" value="exact" {% if match_mode == "exact" %}checked{% endif %}>
+                            <span>完全一致</span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
     </form>
 
-    {% if query %}
+    {% if did_search %}
         <div class="search-users-section">
             {% if object_list %}
                 <ul class="search-users-list">
@@ -31,25 +62,25 @@
                 <div class="pagination">
                     <span class="step-links">
                         {% if object_list.has_previous %}
-                            <a href="{% url 'mysfa:search_users' %}?page=1&q={{ query }}">&laquo; 最初</a>
-                            <a href="{% url 'mysfa:search_users' %}?page={{ object_list.previous_page_number }}&q={{ query }}">前</a>
+                            <a href="{% url 'mysfa:search_users' %}?{% if query_params %}{{ query_params }}&{% endif %}page=1">&laquo; 最初</a>
+                            <a href="{% url 'mysfa:search_users' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ object_list.previous_page_number }}">前</a>
                         {% endif %}
 
                         {% for page_num in object_list.paginator.page_range %}
                             {% if page_num == object_list.number %}
                                 <span class="page-number current">{{ page_num }}</span>
                             {% elif page_num > object_list.number|add:'-3' and page_num < object_list.number|add:'3' %}
-                                <a href="{% url 'mysfa:search_users' %}?page={{ page_num }}&q={{ query }}" class="page-number">{{ page_num }}</a>
+                                <a href="{% url 'mysfa:search_users' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ page_num }}" class="page-number">{{ page_num }}</a>
                             {% elif page_num == 1 or page_num == object_list.paginator.num_pages %}
-                                <a href="{% url 'mysfa:search_users' %}?page={{ page_num }}&q={{ query }}" class="page-number">{{ page_num }}</a>
+                                <a href="{% url 'mysfa:search_users' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ page_num }}" class="page-number">{{ page_num }}</a>
                             {% elif page_num == object_list.number|add:'-3' or page_num == object_list.number|add:'3' %}
                                 <span class="page-ellipsis">...</span>
                             {% endif %}
                         {% endfor %}
 
                         {% if object_list.has_next %}
-                            <a href="{% url 'mysfa:search_users' %}?page={{ object_list.next_page_number }}&q={{ query }}">次</a>
-                            <a href="{% url 'mysfa:search_users' %}?page={{ object_list.paginator.num_pages }}&q={{ query }}">最後 &raquo;</a>
+                            <a href="{% url 'mysfa:search_users' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ object_list.next_page_number }}">次</a>
+                            <a href="{% url 'mysfa:search_users' %}?{% if query_params %}{{ query_params }}&{% endif %}page={{ object_list.paginator.num_pages }}">最後 &raquo;</a>
                         {% endif %}
                     </span>
                 </div>


### PR DESCRIPTION
- 検索ページのみの配置から、各マスタや作成画面等へのリンクを配置
- 検索ページの検索条件機能を拡充

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple user-facing flows (navigation, search filtering/pagination, and post deletion redirects) and adjusts report JSON shape/JS rendering, so regressions could break discovery and reporting despite limited security impact (validated `next` mitigates open-redirect risk).
> 
> **Overview**
> Expands the sidebar from single links into dropdown menus, adding a modal-based group selector that routes users directly to their group page or that group’s product/industry master screens via a new `GET /mysfa/api/my-groups/` endpoint.
> 
> Upgrades group/product/industry/user search pages with *advanced filters* (exact vs partial match, group scoping, membership/lock filters for groups, and date-range filtering for post-based searches), preserves filter params across pagination, and returns to the current filtered view after deleting a post using a validated `next` redirect.
> 
> Improves sales report UX and data: backend now includes product codes in report aggregations, frontend adds cache-busting/no-store fetch, normalizes labels, updates chart colors, and shows a styled empty-state (new `error.png`). Also refreshes group creation form styling/labels via `GroupForm` widgets and new CSS.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8ded5c38f3563e7d083a42ab5e444c1429aa966. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->