### PR TITLE
fix: 投稿表示順 マスタ表示位置を修正

### DIFF
--- a/src/mysfa/models.py
+++ b/src/mysfa/models.py
@@ -68,7 +68,14 @@ class Post(models.Model):
 
     @property
     def product_name(self) -> str:
+        return self.product.name if self.product_id else ""
+
+    @property
+    def industry_name(self) -> str:
         return self.industry.name if self.industry_id else ""
+
+    class Meta:
+        ordering = ["-created_at", "-id"]
 
     def __str__(self):
         return self.product_name


### PR DESCRIPTION
- 投稿表示順の設定が抜けていたので追加
- 商品/業態の表示位置設定が抜けていたので追加