### PR TITLE
chore/ コメントの追加

### DIFF
--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -4,6 +4,7 @@ import re
 from django.contrib import messages
 from django.contrib.auth import get_user_model, logout
 from django.contrib.auth.hashers import check_password
+from django.db import transaction
 from django.http import JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
@@ -239,42 +240,44 @@ class DeleteAccountView(View):
 
         User = get_user_model()
 
-        for group in Group.objects.filter(creator=fresh_user):
-            members = (
-                User.objects.filter(
-                    groupmembership__group=group,
-                    groupmembership__is_active=True,
+        with transaction.atomic():
+            for group in Group.objects.filter(creator=fresh_user):
+                members = (
+                    User.objects.filter(
+                        group_memberships__group=group,
+                        group_memberships__is_active=True,
+                    )
+                    .exclude(pk=fresh_user.pk)
+                    .order_by("custom_user_id")
+                    .distinct()
                 )
-                .exclude(pk=fresh_user.pk)
-                .order_by("custom_user_id")
-                .distinct()
-            )
 
-            if members.exists():
-                group.creator = members.first()
-                group.is_active = True
-                group.save(update_fields=["creator", "is_active"])
-            else:
-                group.creator = None
-                group.is_active = False
-                group.save(update_fields=["creator", "is_active"])
+                if members.exists():
+                    group.creator = members.first()
+                    group.is_active = True
+                    group.save(update_fields=["creator", "is_active"])
+                else:
+                    group.creator = None
+                    group.is_active = False
+                    group.save(update_fields=["creator", "is_active"])
 
-        for group in Group.objects.filter(
-            memberships__user=fresh_user,
-            memberships__is_active=True,
-        ).distinct():
-            GroupMembership.objects.filter(
-                group=group,
-                user=fresh_user,
-                is_active=True,
-            ).update(is_active=False)
+            for group in Group.objects.filter(
+                memberships__user=fresh_user,
+                memberships__is_active=True,
+            ).distinct():
+                GroupMembership.objects.filter(
+                    group=group,
+                    user=fresh_user,
+                    is_active=True,
+                ).update(is_active=False)
 
-            if not GroupMembership.objects.filter(group=group, is_active=True).exists():
-                group.creator = None
-                group.is_active = False
-                group.save(update_fields=["creator", "is_active"])
+                if not GroupMembership.objects.filter(group=group, is_active=True).exists():
+                    group.creator = None
+                    group.is_active = False
+                    group.save(update_fields=["creator", "is_active"])
 
-        fresh_user.delete()
+            fresh_user.delete()
+
         request.session.flush()
         logout(request)
         messages.success(request, "アカウントが削除されました。")

--- a/src/mysfa/views.py
+++ b/src/mysfa/views.py
@@ -1053,6 +1053,8 @@ class JoinGroupView(View):
     def post(self, request, *args, **kwargs):
         group = get_object_or_404(Group, custom_id=kwargs["custom_id"], is_active=True)
 
+        # "72014332" = デモ用グループ
+        # デモユーザーは自動削除されるので、管理者不在の事故防止
         if group.custom_id == "72014332" and group.creator_id is None:
             with transaction.atomic():
                 g = (
@@ -1072,7 +1074,7 @@ class JoinGroupView(View):
             user=request.user,
             defaults={"role": GroupMembership.Role.MEMBER, "is_active": True},
         )
-
+        # OENER権限も付与する
         ensure_membership(request.user, group)
         return redirect("mysfa:group_posts", custom_id=kwargs["custom_id"])
 

--- a/src/mysfa/views.py
+++ b/src/mysfa/views.py
@@ -1589,7 +1589,7 @@ class ProductChangeRequestDecideView(LoginRequiredMixin, View):
                         if not obj:
                             obj = ProductMaster(group=group, product_code=code)
 
-                        # 受け取ったペイロードを反映するが、
+                        # 反映させたくないキーは予め除外
                         for key, value in data.items():
                             if key in (
                                 "_target_pk",

--- a/src/mysfa/views.py
+++ b/src/mysfa/views.py
@@ -487,6 +487,7 @@ class TrialStartView(View):
 class Timeline(LoginRequiredMixin, ListView):
     model = Post
     template_name = "post/timeline.html"
+    # TODO: デフォルト名をわざわざ指定してしまっている → "post"に変更の上、該当template参照箇所も同時に修正
     context_object_name = "object_list"
     paginate_by = 10
 

--- a/src/mysfa/views.py
+++ b/src/mysfa/views.py
@@ -82,7 +82,8 @@ def _validate_product_csv(group, file_obj):
     import io
     import unicodedata
 
-    # アップロードされたcsvファイルを一度 bytes のまま受ける
+    # アップロードされたcsvファイルは文字コードがユーザーによりバラバラ
+    # 一度 bytes のまま受けとり、utf-8,cp932でデコード
     raw = file_obj.read()
 
     def _decode_bytes(b: bytes) -> str:
@@ -138,7 +139,7 @@ def _validate_product_csv(group, file_obj):
     headers = PRODUCT_CSV_HEADERS
     reader = (
         # 列番号依存解消/可読性を上げる為、CSV行を「ヘッダー名→値」の辞書に変換
-        # NULL列の空欄保管/余剰列の切り捨てでエラー防止
+        # NULL列の空欄補完/余剰列の切り捨てでエラー防止
         dict(zip(headers, (row + [""] * len(headers))[: len(headers)]))
         for row in csv_reader
     )
@@ -914,7 +915,7 @@ class GroupAdminView(LoginRequiredMixin, View):
         group = get_object_or_404(Group, custom_id=custom_id, is_active=True)
         require_group_admin(request.user, group)
 
-        # 旧データ救済：Group.users にいるのに membership が無いユーザーを作る
+        # 旧データ救済：Group.usersにいるのにmembershipが無いユーザーを作る
         members = group.users.all().select_related()
         existing = {
             (m.user_id): m
@@ -1160,7 +1161,7 @@ class LeaveGroupView(View):
         request.user.groups.remove(group)
 
         with transaction.atomic():
-            # Remove membership (no history)
+            # 退会履歴を保持せず、その場でレコード削除
             GroupMembership.objects.filter(
                 group=group,
                 user=request.user,
@@ -1587,7 +1588,7 @@ class ProductChangeRequestDecideView(LoginRequiredMixin, View):
                         if not obj:
                             obj = ProductMaster(group=group, product_code=code)
 
-                        # apply payload (ignore unknown keys)
+                        # 受け取ったペイロードを反映するが、
                         for key, value in data.items():
                             if key in (
                                 "_target_pk",

--- a/src/mysfa/views.py
+++ b/src/mysfa/views.py
@@ -504,14 +504,12 @@ class Timeline(LoginRequiredMixin, ListView):
                 Post.objects.filter(group=group)
                 .select_related("user", "group", "product", "industry")
                 .prefetch_related("comments__author")
-                .distinct()
             )
         else:
             queryset = (
                 Post.objects.filter(group__in=user_groups)
                 .select_related("user", "group", "product", "industry")
                 .prefetch_related("comments__author")
-                .distinct()
             )
         return queryset
 

--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -4041,7 +4041,7 @@
         }
 
         .main-content-login .form-guide-inner {
-            align-items: stretch;
+            align-items: center;
         }
 
         .main-content-login .form-guide-inner > a.guide-button,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches group ownership and membership updates during account deletion/join flows, so bugs could leave inconsistent `Group`/`GroupMembership` state. Also changes timeline query semantics by removing `.distinct()`, which may affect duplicates/pagination depending on joins.
> 
> **Overview**
> Makes user account deletion update related group ownership/memberships inside a single `transaction.atomic()` block, including switching the membership join used to select the next creator.
> 
> Hardens demo-group joining by assigning a creator under a row lock when the demo group has none, and removes `.distinct()` from the timeline post queryset. Minor doc/comment tweaks to CSV handling and product change-approval filtering, plus a small CSS tweak to center login-page guide buttons on small screens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d329cc996726cab6aee25eac660d17df468ea79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->